### PR TITLE
Fixed bug in parse all function, where setting the order to

### DIFF
--- a/BatotoFrame.py
+++ b/BatotoFrame.py
@@ -274,10 +274,11 @@ class BatotoFrame(wx.Frame):
 					lines.append(self.URLList.GetLineText(count))
 					count += 1
 			else:
-				count = totalLines
-				while count > 0:
+				count = totalLines - 1
+				while count >= 0:
 					lines.append(self.URLList.GetLineText(count))
 					count -= 1
+			print lines
 			self.thread = BatotoThread(0, lines, self, oldOrder)
 
 	def Cancel(self, e):


### PR DESCRIPTION
newest first would cause the last entry to be downloaded twice,
and the first entry to be skipped