### PR TITLE
Extracted selected group & chapter name, not the first.

### DIFF
--- a/URLParser.py
+++ b/URLParser.py
@@ -295,10 +295,10 @@ class URLParser:
 				#with open('/tmp/batoto.txt', 'w') as dlfile:
 				#	dlfile.write(req.data)
 
-				group = dom.xpath(".//*[@name='group_select']/option/text()")[0]
+				group = dom.xpath(".//*[@name='group_select']/option[@selected='selected']/text()")[0]
 				group = group[:group.rindex(' -')]
 				series = dom.xpath(".//ul/li/a")[0].text
-				chapter = dom.xpath(".//*[@name='chapter_select']/option/text()")[0]
+				chapter = dom.xpath(".//*[@name='chapter_select']/option[@selected='selected']/text()")[0]
 				pFormat = dom.xpath(".//img[starts-with(@src, 'http://img.bato.to/comics/2')]/@src")
 				#comics/2 ensures we only get comics from year 2000 onwards; not misc images in comics dir
 				pages = dom.xpath(".//*[@name='page_select']")


### PR DESCRIPTION
Update the xpath query to get the selected field. This allows non-current releases to be correctly fetched.